### PR TITLE
Fix typos in app_admin secrets instructions

### DIFF
--- a/pages/app_admin.py
+++ b/pages/app_admin.py
@@ -487,8 +487,8 @@ def main():
            
 
 
-    st.write("This is how to setup sercets in streamlit at local environment https://docs.streamlit.io/develop/concepts/connections/secrets-management")
-    st.write("This is how to setup sercets in streamlit at cloud https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management")
+    st.write("This is how to setup secrets in streamlit at local environment https://docs.streamlit.io/develop/concepts/connections/secrets-management")
+    st.write("This is how to setup secrets in streamlit at cloud https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- fix typos for `secrets` in `pages/app_admin.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421fcff17c832a82becb3a7c338ad0