### PR TITLE
Add unit tests for app and crawler

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 # make this a package
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+_dummy_nvidia = ModuleType('langchain_nvidia_ai_endpoints')
+_dummy_nvidia.ChatNVIDIA = MagicMock()
+_dummy_genai = ModuleType('google.generativeai')
+_dummy_genai.configure = MagicMock()
+_dummy_lgg = ModuleType('langchain_google_genai')
+_dummy_lgg.GoogleGenerativeAIEmbeddings = MagicMock(return_value=object())
+_dummy_lgg.ChatGoogleGenerativeAI = MagicMock()
+_dummy_assembly = ModuleType('assemblyai')
+
+
+def test_get_prompt_template():
+    mock_prompt = MagicMock(return_value='tmpl')
+    with patch.dict(sys.modules, {
+        'langchain_nvidia_ai_endpoints': _dummy_nvidia,
+        'google.generativeai': _dummy_genai,
+        'langchain_google_genai': _dummy_lgg,
+        'assemblyai': _dummy_assembly,
+    }), \
+         patch('streamlit.secrets', {"NVIDIA_API_KEY": "dummy", "GOOGLE_API_KEY": "dummy", "ASSEMBLYAI_API_KEY": "dummy"}), \
+         patch('langchain_community.vectorstores.FAISS', MagicMock()), \
+         patch('langchain.prompts.PromptTemplate', mock_prompt):
+        app = importlib.import_module('app')
+        template = app.get_prompt_template()
+    assert template == 'tmpl'
+    mock_prompt.assert_called_once()
+
+
+def test_get_text_chunks_split():
+    with patch.dict(sys.modules, {
+        'langchain_nvidia_ai_endpoints': _dummy_nvidia,
+        'google.generativeai': _dummy_genai,
+        'langchain_google_genai': _dummy_lgg,
+        'assemblyai': _dummy_assembly,
+    }), \
+         patch('streamlit.secrets', {"GOOGLE_API_KEY": "dummy", "ASSEMBLYAI_API_KEY": "dummy"}), \
+         patch('langchain_community.vectorstores.FAISS', MagicMock()):
+        pages = importlib.import_module('pages.app_admin')
+        get_text_chunks = pages.get_text_chunks
+    text = 'A' * 6000
+    chunks = get_text_chunks(text)
+    assert len(chunks) >= 2
+

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,19 @@
+from webcrawer import WebCrawler
+from unittest.mock import patch
+
+
+def mock_get(*args, **kwargs):
+    class Response:
+        def __init__(self, text):
+            self.text = text
+    html = '<html><body><a href="https://example.com/page">Page</a></body></html>'
+    return Response(html)
+
+
+def test_crawl_returns_root():
+    crawler = WebCrawler('https://example.com', max_depth=1)
+    with patch('requests.get', side_effect=mock_get):
+        urls = crawler.start_crawling('https://example.com')
+    assert 'https://example.com' in urls
+    assert isinstance(urls, set)
+


### PR DESCRIPTION
## Summary
- add new unit tests for core functions
- include placeholder package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684223337874832ab5e9270d667ec3d9